### PR TITLE
Add Authorization Code Flow

### DIFF
--- a/spotipy2/auth/__init__.py
+++ b/spotipy2/auth/__init__.py
@@ -1,5 +1,6 @@
 from .base_auth_flow import BaseAuthFlow
 from .client_credentials_flow import ClientCredentialsFlow
+from .oauth_flow import OauthFlow
 from .token import Token
 
-__all__ = ["BaseAuthFlow", "ClientCredentialsFlow", "Token"]
+__all__ = ["BaseAuthFlow", "ClientCredentialsFlow", "Token", "OauthFlow"]

--- a/spotipy2/auth/base_auth_flow.py
+++ b/spotipy2/auth/base_auth_flow.py
@@ -1,7 +1,13 @@
+from base64 import b64encode
+
+
 class BaseAuthFlow:
-    def __init__(self) -> None:
-        raise TypeError(
-            "Base types can only be used for type checking purposes: "
-            "you tried to use a base type instance as argument, "
-            "but you need to instantiate one of its subclass instead. "
-        )
+    async def make_auth_header(self) -> dict:
+        return {
+            "Authorization": "Basic %s"
+                             % b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
+        }
+
+    @staticmethod
+    async def wrapper(**kwargs):
+        return {k: v for k, v in kwargs.items() if v is not None}

--- a/spotipy2/auth/client_credentials_flow.py
+++ b/spotipy2/auth/client_credentials_flow.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from base64 import b64encode
 from aiohttp import ClientSession
 from datetime import datetime, timezone
 
@@ -26,9 +25,3 @@ class ClientCredentialsFlow(BaseAuthFlow):
             API_URL, data=GRANT_TYPE, headers=await self.make_auth_header()
         ) as r:
             return await Token.from_dict(await r.json())
-
-    async def make_auth_header(self) -> dict:
-        return {
-            "Authorization": "Basic %s"
-            % b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
-        }

--- a/spotipy2/auth/oauth_flow.py
+++ b/spotipy2/auth/oauth_flow.py
@@ -1,0 +1,278 @@
+from base64 import b64encode
+from typing import Optional, List, Callable
+from aiohttp import web, ClientSession
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .base_auth_flow import BaseAuthFlow
+from .token import Token
+from ..exceptions import SpotifyException
+
+import urllib.parse
+import re
+import secrets
+import asyncio
+
+
+class OauthFlow(BaseAuthFlow):
+    def __init__(
+            self,
+            client_id: str,
+            client_secret: str,
+            redirect_uri: Optional[str] = "http://localhost:9000",
+            scope: Optional[List[str]] = None,
+            open_browser: Optional[bool] = None,
+            token: Optional[Token] = None,
+            authenticated_html_response: Optional[str] = Path(__file__).parent / "./static/authenticated.html",
+            # See ^1 (below)
+            failed_html_response: Optional[str] = Path(__file__).parent / "./static/failed.html",
+            state_verifier: Optional[Callable[[str], bool]] = None,
+            disable_builtin_server: Optional[bool] = False,
+    ) -> None:
+        """
+        ### Args
+        - client_id: `str`, Spotify client id
+        - client_secret: `str`, Spotify client secret
+        - redirect_uri: `str`, URI for Oauth callback, URI(s) using localhost (127.0.0.1)
+        will automatically start spotipy2's built-in server. URI must match one of the URI's on
+        the project's Spotify Dashboard character for character
+        - scope: `Optional[List[str]]`, List of Spotify scopes,
+        full list: https://developer.spotify.com/documentation/general/guides/authorization/scopes/
+        - open_browser: `Optional[bool]`, Whether to force the user to approve the app again if they have already done so
+        - token: `Optional[str]`, length of the song in seconds
+        - authenticated_html_response: `Optional[str]`, The path to a html file which will be displayed if a user is
+        successfully authenticated, only works when using spotipy2's built-in server
+        - failed_html_response: `Optional[str]`, The path to a html file which will be displayed if a user is
+        NOT successfully authenticated, only works when using spotipy2's built-in server
+        - state_verifier: `Optional[Callable[[str], bool]]`, Method to be executed to verify state to prevent XSS attack
+        - disable_builtin_server: `Optional[bool]`, If True, the built-in server will not be started
+
+        ### Returns
+        - `None`
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - For spotipy2's built-in server to start, the redirect_uri must contain localhost as
+        the domain as well as the port, eg. http://localhost:9000. No path should be specified and HTTPS cannot be used
+        and will be converted to HTTP. If you would like to use HTTPS, consider setting up your own web server.
+        In addition, you must call the get_redirect method before executing any requests
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.open_browser = open_browser if open_browser else str(open_browser).lower()
+        self.token = token
+        self.authenticated_html_response = authenticated_html_response
+        self.failed_html_response = failed_html_response
+        self.disable_builtin_server = disable_builtin_server
+        self.header = {
+            "Authorization": "Basic %s"
+                             % b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
+        }
+
+        self.state_verifier = state_verifier if state_verifier else self._state_verifier
+
+        self.expected_state = secrets.token_urlsafe(16)
+
+        self.server = None  # Oauth server
+        self.server_runner = None
+
+        self.timeout = 3
+
+    async def get_redirect(self) -> str:
+        """
+        ### Args
+        - None
+
+        ### Returns
+        - `str`, The authentication URI which the user must navigate to in order to get authenticated
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - This will automatically start spotipy2's built-in server if the redirect_uri contains localhost as
+        the domain as well as the port, eg. http://localhost:9000.
+        """
+        API_URL = "https://accounts.spotify.com/authorize?"
+
+        data = await self.wrapper(
+            response_type="code",
+            client_id=self.client_id,
+            scope=" ".join(self.scope),
+            redirect_uri=self.redirect_uri,
+            show_dialog=self.open_browser,
+            state=self.expected_state,
+        )
+
+        self.redirect_uri = self.redirect_uri.replace("https://", "http://")
+
+        regex = '(?:http.*://)?(?P<host>[^:/ ]+).?(?P<port>[0-9]*).*'
+        result = re.search(regex, self.redirect_uri)
+        if result.group("host") in ['localhost', '127.0.0.1'] and not self.disable_builtin_server:
+            if result.group("port") != '':
+                self.server = OauthServer(self.authenticated_html_response,
+                                          self.failed_html_response,
+                                          self.state_verifier)
+                runner = web.AppRunner(self.server)
+                await runner.setup()
+                self.server_runner = web.TCPSite(runner, 'localhost', int(result.group("port")))
+                # We don't need to implement any code for graceful shutdown as we don't do anything such as data
+                # streaming
+                await self.server_runner.start()
+
+        return API_URL + urllib.parse.urlencode(data)
+
+    async def get_access_token(self, http: ClientSession) -> Token:
+        """
+        ### Args
+        - http: `ClientSession`, Aiohttp ClientSession to use
+
+        ### Returns
+        - `Token`, The access token
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - None
+        """
+        if self.token and self.token.expires_at > datetime.now(timezone.utc):
+            return self.token
+        elif self.token and self.token.expires_at < datetime.now(timezone.utc):
+            return await self.refresh_token(http)
+        if not self.disable_builtin_server:
+            while not self.server.code:
+                await asyncio.sleep(self.timeout)
+            code = self.server.code
+        else:
+            url = input("Please paste the URI you were redirected to: ")
+            processed_url = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+            code = processed_url.get('code')
+            state = processed_url.get('state')[0]
+            if code:
+                if await self._state_verifier(state):
+                    code = code[0]
+                else:
+                    raise RuntimeError(f"State does not match. State: {state}")
+            else:
+                raise SpotifyException(403, f"Authentication failed. State: {state}")
+        self.token = await self._get_access_token(code,
+                                                  self.client_id,
+                                                  self.client_secret,
+                                                  self.redirect_uri,
+                                                  http)
+        return self.token
+
+    @staticmethod
+    async def _get_access_token(token: str, client_id: str, client_secret: str, redirect_uri: str,
+                                http: ClientSession) -> Token:
+        """
+        ### Args
+        - token: `str`, 'code' returned from Oauth callback (redirect_uri), this is NOT the access token
+        - client_id: `str`, Spotify client id
+        - client_secret: `str`, Spotify client secret
+        - redirect_uri: `str`, URI for Oauth callback, URI must match one of the URI's on
+        the project's Spotify Dashboard character for character
+        - http: `ClientSession`, Aiohttp ClientSession to use
+
+        ### Returns
+        - `Token`, The access token
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - This method is static so that developers who have already gotten the 'code' through their own code (for eg.
+        they already have a separate website using flask) can easily use this method and instantiate a new auth
+        flow with the access token which is returned
+        """
+
+        API_URL = "https://accounts.spotify.com/api/token"
+        data = {
+            "code": token,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code"
+        }
+
+        HEADER = {
+            "Authorization": "Basic %s"
+                             % b64encode(f"{client_id}:{client_secret}".encode()).decode()
+        }
+
+        async with http.post(
+                API_URL, data=data, headers=HEADER
+        ) as r:
+            return await Token.from_dict(await r.json())
+
+    async def refresh_token(self, http: ClientSession) -> Token:
+        """
+        ### Args
+        - http: `ClientSession`, Aiohttp ClientSession to use
+
+        ### Returns
+        - `Token`, The access token
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - None
+        """
+        API_URL = "https://accounts.spotify.com/api/token"
+        data = {
+            "refresh_token": self.token.refresh_token,
+            "grant_type": "refresh_token"
+        }
+
+        HEADER = self.header
+
+        async with http.post(
+                API_URL, form=data, headers=HEADER
+        ) as r:
+            response = await r.json()
+            # Refresh token is not received on token refresh
+            response["refresh_token"] = self.token.refresh_token
+            self.token = await Token.from_dict(response)
+            return self.token
+
+    async def _state_verifier(self, state: str) -> bool:
+        """
+        ### Args
+        - state: `str`, State to verify
+
+        ### Returns
+        - `bool`, True if it is correct, False if not
+
+        ### Errors raised
+        - None
+
+        ### Function / Notes
+        - This is spotipy2's built in state_verifier
+        """
+        return state == self.expected_state
+
+
+class OauthServer(web.Application):
+    def __init__(self, authenticated_html_response: str, failed_html_response: str, state_verifier: Callable):
+        self.code = None  # The code is *not* the access token
+        self.state = None
+
+        self.authenticated_html_response = authenticated_html_response
+        self.failed_html_response = failed_html_response
+        self.state_verifier = state_verifier
+
+        super().__init__()
+        self.add_routes([web.get('/', self.authorized)])
+
+    async def authorized(self, request):
+        self.state = request.rel_url.query['state']
+
+        if await self.state_verifier(self.state):
+            self.code = request.rel_url.query['code']
+            return web.FileResponse(self.authenticated_html_response)
+        else:
+            return web.FileResponse(self.failed_html_response)

--- a/spotipy2/auth/oauth_flow.py
+++ b/spotipy2/auth/oauth_flow.py
@@ -43,7 +43,7 @@ class OauthFlow(BaseAuthFlow):
         full list: https://developer.spotify.com/documentation/general/guides/authorization/scopes/
         - show_dialog: `Optional[bool]`, Whether to force the user to approve the app again if they have already done so
         - open_browser: `Optional[bool]`, Whether to open the browser or not when get_redirect is called
-        - token: `Optional[str]`, length of the song in seconds
+        - token: `Optional[str]`, The access token
         - authenticated_html_response: `Optional[str]`, The path to a html file which will be displayed if a user is
         successfully authenticated, only works when using spotipy2's built-in server
         - failed_html_response: `Optional[str]`, The path to a html file which will be displayed if a user is

--- a/spotipy2/auth/static/authenticated.html
+++ b/spotipy2/auth/static/authenticated.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spotipy2</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+<div class="w-screen h-screen bg-gray-50 flex items-center justify-center">
+    <div class="p-2 h-3/4 bg-white shadow-2xl rounded-lg">
+        <img src="https://camo.githubusercontent.com/3eec18b07d910260886735800984c2fcce1fa419b11d529e1b1e38e9cda86205/68747470733a2f2f73766773686172652e636f6d2f692f5354432e737667"
+             alt="Spotipy2 Logo"
+             class="h-28"
+        />
+        <div class="flex items-center justify-center flex-col" style="height: inherit;">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-20 w-20 stroke-green-500" fill="none"
+                 viewBox="0 0 24 24" stroke="currentColor"
+                 stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            <p class="text-xl font-bold">Authorized Successfully!</p>
+            <p class="font-thin">You can close this tab now</p>
+        </div>
+        <p class="font-thin text-center">Made with love using Spotipy2</p>
+    </div>
+    <p id="state" class="p-2 absolute bottom-0 left-0">State: </p>
+</div>
+
+<script>
+    const url = new URL(window.location.href);
+    document.getElementById("state").appendChild(document.createTextNode(url.searchParams.get("state")));
+</script>
+</body>
+</html>

--- a/spotipy2/auth/static/failed.html
+++ b/spotipy2/auth/static/failed.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spotipy2</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+<div class="w-screen h-screen bg-gray-50 flex items-center justify-center">
+    <div class="p-2 h-3/4 bg-white shadow-2xl rounded-lg">
+        <img src="https://camo.githubusercontent.com/3eec18b07d910260886735800984c2fcce1fa419b11d529e1b1e38e9cda86205/68747470733a2f2f73766773686172652e636f6d2f692f5354432e737667"
+             alt="Spotipy2 Logo"
+             class="h-28"
+        />
+        <div class="flex items-center justify-center flex-col" style="height: inherit;">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-20 w-20 stroke-red-500" fill="none"
+                 viewBox="0 0 24 24" stroke="currentColor"
+                 stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            <p class="text-xl font-bold">Authentication Failed</p>
+            <p class="font-thin">Contact the owner of this application</p>
+        </div>
+        <p class="font-thin text-center">Made with love using Spotipy2</p>
+    </div>
+    <p id="state" class="p-2 absolute bottom-0 left-0">State: </p>
+</div>
+
+<script>
+    const url = new URL(window.location.href);
+    document.getElementById("state").appendChild(document.createTextNode(url.searchParams.get("state")));
+</script>
+</body>
+</html>

--- a/spotipy2/client.py
+++ b/spotipy2/client.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from typing import Optional, Type
+from typing import Optional, Union
 
 import re
 import logging
 import asyncio
 from aiohttp import ClientSession
 
-from spotipy2.auth import BaseAuthFlow
+from spotipy2.auth import ClientCredentialsFlow, OauthFlow
 from spotipy2.methods import Methods
 from spotipy2.exceptions import SpotifyException
 
@@ -16,7 +16,7 @@ class Spotify(Methods):
 
     def __init__(
         self,
-        auth_flow: Type[BaseAuthFlow],
+        auth_flow: Union[ClientCredentialsFlow, OauthFlow],
         mongodb_uri: Optional[str] = None,
         *args,
         **kwargs,

--- a/spotipy2/client.py
+++ b/spotipy2/client.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, Type
 
 import re
 import logging
 import asyncio
 from aiohttp import ClientSession
 
-from spotipy2.auth import ClientCredentialsFlow
+from spotipy2.auth import BaseAuthFlow
 from spotipy2.methods import Methods
 from spotipy2.exceptions import SpotifyException
 
@@ -16,7 +16,7 @@ class Spotify(Methods):
 
     def __init__(
         self,
-        auth_flow: ClientCredentialsFlow,
+        auth_flow: Type[BaseAuthFlow],
         mongodb_uri: Optional[str] = None,
         *args,
         **kwargs,

--- a/spotipy2/methods/playlists.py
+++ b/spotipy2/methods/playlists.py
@@ -48,4 +48,4 @@ class PlaylistMethods:
             offset += len(playlist_tracks["items"])
 
             if not playlist_tracks["next"]:
-                return None
+                return


### PR DESCRIPTION
As the title suggests, this PR adds the Authorization Code Flow (PCKE Not included) to spotipy2. There are an array of different ways for developers to use the Authorization Code Flow, or rather interact with/use it. The methods have been ranked by complexity.

## Example Usages
### Method 1
By setting the `redirect_uri` to somewhere on `localhost` (`127.0.0.1`), the built-in server will automatically be started (unless forcefully refused by the `disable_builtin_server` parameter). The built-in server will catch the OAuth callback sent from the Spotify API.
```python
import asyncio
from spotipy2 import Spotify
from spotipy2.auth import OauthFlow

flow = OauthFlow(
    client_id="CLIENT_ID",
    client_secret="CLIENT_SECRET",
    redirect_uri="http://localhost:9000",
    scope=["user-read-playback-state"],
    open_browser=True,
    show_dialog=True
)


async def main():
    print(await flow.get_redirect())
    client = Spotify(flow)

    async with client as s:
        track = await s.get_track("5Z9KJZvQzH6PFmb8SNkxuk?si=426e3bc9b0eb46fa")
        print(f"The name of the track is {track.name}")


asyncio.get_event_loop().run_until_complete(main())
```
### Method 2
If the developer cannot setup their own webserver or use spotipy2's built-in server, the user will be prompted to paste in the URI that they were redirected to after authorization.
```python
flow = OauthFlow(
    client_id="CLIENT_ID",
    client_secret="CLIENT_SECRET",
    redirect_uri="http://localhost:9000",
    scope=["user-read-playback-state"],
    show_dialog=True,
    disable_builtin_server=True
)
```
### Method 3
If the developer has already obtained the `access_token` (they will most probably have the `code` which is not the same as the access token, but they can convert that to an access token through the `_get_access_token` static helper method) through their own code or separate webserver/backend, etc, the developer can simply just provide the `code` through the `token` parameter
```python
flow = OauthFlow(
    client_id="CLIENT_ID",
    client_secret="CLIENT_SECRET",
    redirect_uri="http://localhost:9000",
    scope=["user-read-playback-state"],
    token="TOKEN"
)
```

## What's Included

- [x] Docstrings
- [x] Compatibility with headless applications
- [x] Token Refreshing
- [x] State verification to prevent XSS attacks
- [x] Built-in server 