### PR TITLE
Fix token refresh

### DIFF
--- a/spotipy2/auth/oauth_flow.py
+++ b/spotipy2/auth/oauth_flow.py
@@ -236,7 +236,7 @@ class OauthFlow(BaseAuthFlow):
         HEADER = self.header
 
         async with http.post(
-                API_URL, form=data, headers=HEADER
+                API_URL, data=data, headers=HEADER
         ) as r:
             response = await r.json()
             # Refresh token is not received on token refresh


### PR DESCRIPTION
`refresh_token` called `http.post` with `form=data` which resulted in an TypeError: https://github.com/Lykos153/maubot-spotify/issues/24 This commit fixes the call to use `data=data` as `_get_access_token` does.