### PR TITLE
Add check for unsuccesful token retrieval

### DIFF
--- a/spotipy2/auth/oauth_flow.py
+++ b/spotipy2/auth/oauth_flow.py
@@ -211,6 +211,8 @@ class OauthFlow(BaseAuthFlow):
         async with http.post(
                 API_URL, data=data, headers=HEADER
         ) as r:
+            if r.status < 200 or r.status > 299:
+                raise SpotifyException(r.status, r.json()) # example: {'error': 'invalid_grant', 'error_description': 'Invalid redirect URI'}
             return await Token.from_dict(await r.json())
 
     async def refresh_token(self, http: ClientSession) -> Token:


### PR DESCRIPTION
When trying to retrieve the token, Spotify might reply with an error like `{'error': 'invalid_grant', 'error_description': 'Invalid redirect URI'}` which results in an inexpressive KeyError in `Token.from_dict`.

This commit adds a check for the HTTP status code that raises a SpotifyException including the response body in case of error.